### PR TITLE
Add control over threads via. CLI argument

### DIFF
--- a/tools/ffmpeg.py
+++ b/tools/ffmpeg.py
@@ -27,6 +27,7 @@ import re
 import concurrent.futures
 import subprocess
 
+
 def get_ref_md5(fn):
     dir = dirname(fn)
     name = basename(fn)
@@ -35,16 +36,14 @@ def get_ref_md5(fn):
     if o.returncode:
         return None
     o = o.stdout.decode()
-    return o.replace("  "+name, "").strip()
+    return o.replace("  " + name, "").strip()
 
-def get_md5(input):
-    cmd = os.getenv('FFMPEG_PATH')
-    if not cmd:
-        print("print define FFMPEG_PATH in your env")
-    cmd  = cmd + " -i " + input + " -vsync 0 -f md5 -"
+
+def get_md5(input, ffmpeg_path):
+    cmd = ffmpeg_path + " -i " + input + " -vsync 0 -f md5 -"
     print(cmd)
     try:
-        o = subprocess.run(cmd.split(), capture_output=True, timeout = 5 * 60)
+        o = subprocess.run(cmd.split(), capture_output=True, timeout=5 * 60)
         if o.returncode:
             print(o.stderr)
             return ""
@@ -52,32 +51,32 @@ def get_md5(input):
     except Exception as e:
         return str(e)
 
+
 PASSED = 0
 FAILED = 1
 SKIPPED = 2
-def test(f):
+
+
+def test(f, args):
     refmd5 = get_ref_md5(f)
     if not refmd5:
         print(basename(f) + " has no ref md5")
         return SKIPPED
 
-    md5 = get_md5(f)
+    md5 = get_md5(f, args.ffmpeg_path)
     if refmd5 == md5:
         return PASSED
 
-    print("md5 mismatch ref = " + refmd5 + " md5 = "+md5)
+    print("md5 mismatch ref = " + refmd5 + " md5 = " + md5)
     return FAILED
+
 
 def is_candidiate(f):
     filename, ext = os.path.splitext(f)
     ext = ext.lower()
-    supported = [
-        ".bin",
-        ".bit",
-        ".vvc",
-        ".266"
-    ]
+    supported = [".bin", ".bit", ".vvc", ".266"]
     return ext in supported
+
 
 def check_input():
     argc = len(sys.argv)
@@ -86,10 +85,12 @@ def check_input():
         sys.exit(1)
     return sys.argv[1]
 
-def test_file(path):
-    pss = test(path)
+
+def test_file(path, args):
+    pss = test(path, args)
     print(basename(path) + " passed" if pss == PASSED else " failed")
     return 0
+
 
 def print_files(name, files):
     if len(files) > 0:
@@ -97,8 +98,10 @@ def print_files(name, files):
         for f in files:
             print("    " + f)
 
+
 count = [0, 0, 0]
 summary = [[], [], []]
+
 
 def print_summary():
     print("")
@@ -107,27 +110,38 @@ def print_summary():
     print_files("skipped", summary[SKIPPED])
     print_files("passed", summary[PASSED])
     print("")
-    print("total = "+ str(count[PASSED] + count[FAILED] + count[SKIPPED]) +", passed = " + str(count[PASSED]) + ", failed = "+ str(count[FAILED]) + ", skipped = " + str(count[SKIPPED]))
+    print(
+        "total = "
+        + str(count[PASSED] + count[FAILED] + count[SKIPPED])
+        + ", passed = "
+        + str(count[PASSED])
+        + ", failed = "
+        + str(count[FAILED])
+        + ", skipped = "
+        + str(count[SKIPPED])
+    )
     print("----------")
 
-def submmit_files(executor, path):
+
+def submmit_files(executor, path, args):
     future_to_file = {}
     for root, dirs, files in os.walk(path):
         for f in files:
             fn = join(root, f)
             if is_candidiate(fn):
-                future_to_file[executor.submit(test, fn)] = f
+                future_to_file[executor.submit(test, fn, args)] = f
     return future_to_file
 
-def test_dir(path):
-    with concurrent.futures.ThreadPoolExecutor(max_workers=4) as executor:
-        future_to_file = submmit_files(executor, path)
+
+def test_dir(path, args):
+    with concurrent.futures.ThreadPoolExecutor(max_workers=args.threads) as executor:
+        future_to_file = submmit_files(executor, path, args)
         for future in concurrent.futures.as_completed(future_to_file):
             f = future_to_file[future]
             try:
                 s = future.result()
             except Exception as e:
-                print('%s generated an exception: %s' % (f, e))
+                print("%s generated an exception: %s" % (f, e))
             else:
                 count[s] += 1
                 summary[s].append(f)
@@ -135,6 +149,30 @@ def test_dir(path):
     print_summary()
     sys.exit(count[FAILED])
 
+
 if __name__ == "__main__":
-    path = check_input()
-    test_file(path) if os.path.isfile(path) else test_dir(path)
+    import argparse
+
+    parser = argparse.ArgumentParser(description="FFVVC test runner")
+
+    parser.add_argument("test_path", type=str)
+    parser.add_argument("-t", "--threads", type=int, default=4)
+    parser.add_argument(
+        "-f",
+        "--ffmpeg-path",
+        type=str,
+        default=(os.getenv("FFMPEG_PATH") if os.getenv("FFMPEG_PATH") else None),
+    )
+    args = parser.parse_args()
+
+    if args.ffmpeg_path is None:
+        print(
+            "No FFmpeg path provided. Please provide a path to an FFmpeg executable either with -f, --ffmpeg-path or the environment variable FFMPEG_PATH.",
+            file=sys.stderr,
+        )
+        exit(1)
+
+    if os.path.isfile(args.test_path):
+        test_file(args.test_path, args)
+    else:
+        test_dir(args.test_path, args)


### PR DESCRIPTION
This PR primarily adds control over the maximum number of threads. As there were getting to be a fair few parameters to this test runner, this is done using a CLI argument via. argparse. Defaults are provided for backward compatibility.