### PR TITLE
fix unneeded requirement for "--vvdec-path"

### DIFF
--- a/tools/perf.py
+++ b/tools/perf.py
@@ -65,7 +65,7 @@ class PerformanceRunner(TestRunner):
         self.__print_summary()
 
     def add_args(self, parser):
-        parser.add_argument("--vvdec-path", type=str, required=True)
+        parser.add_argument("--vvdec-path", type=str)
 
     def __get_app(self):
         if self.args.vvdec_path:

--- a/tools/runner.py
+++ b/tools/runner.py
@@ -39,7 +39,7 @@ class TestRunner:
 
         self.args = parser.parse_args()
 
-        if not self.args.ffmpeg_path:
+        if not self.args.vvdec_path and not self.args.ffmpeg_path:
             return Exception(
                 "No FFmpeg path provided. Please provide a path to an FFmpeg executable either with -f, --ffmpeg-path or the environment variable FFMPEG_PATH."
             )

--- a/tools/runner.py
+++ b/tools/runner.py
@@ -39,7 +39,8 @@ class TestRunner:
 
         self.args = parser.parse_args()
 
-        if not self.args.vvdec_path and not self.args.ffmpeg_path:
+        not_vvdec = hasattr(self.args, "vvdec_path") and not self.args.vvdec_path
+        if  not_vvdec and not self.args.vvdec_path and not self.args.ffmpeg_path:
             return Exception(
                 "No FFmpeg path provided. Please provide a path to an FFmpeg executable either with -f, --ffmpeg-path or the environment variable FFMPEG_PATH."
             )


### PR DESCRIPTION
perf.py path will failed like this:

> usage: perf.py [-h] [-f FFMPEG_PATH] --vvdec-path VVDEC_PATH test_path
> perf.py: error: the following arguments are required: --vvdec-path

the patch will fix it