### PR TITLE
Add timeout flag to test runner

### DIFF
--- a/tools/ffmpeg.py
+++ b/tools/ffmpeg.py
@@ -78,6 +78,8 @@ class ConformanceRunner(TestRunner):
 
     def add_args(self, parser):
         parser.add_argument("-t", "--threads", type=int, default=4)
+        parser.add_argument("-s", "--timeout", type=int, default=0,
+                            help="Number of seconds before test fails due to timeout. Negative values and zero never fail due to timeout.")
 
     def __test_file(self):
         pss = self.__test(self.args.test_path)
@@ -88,7 +90,11 @@ class ConformanceRunner(TestRunner):
         cmd = self.args.ffmpeg_path + " -i " + input + " -vsync 0 -f md5 -"
         print(cmd)
         try:
-            o = subprocess.run(cmd.split(), capture_output=True, timeout=5 * 60)
+            if self.args.timeout > 0:
+                o = subprocess.run(cmd.split(), capture_output=True, timeout=self.args.timeout)
+            else:
+                o = subprocess.run(cmd.split(), capture_output=True)
+
             if o.returncode:
                 print(o.stderr)
                 return ""


### PR DESCRIPTION
Add timeout flag to test runner. Default set to zero (unlimited). This is different to the previous default (300s), however note GitHub actions has a built-in timeout. This defaults to 360 minutes per job so we may want to reduce this in the [ffvvc/FFmpeg](https://github.com/ffvvc/FFmpeg) workflow file.

Maybe we could test the conformance bitstreams without a timeout, then the performance bitstreams with a timeout? The GitHub actions runners' performance seems to vary, so it may be difficult to derive a suitable figure which balances being meaningful with avoiding false negatives however.