### PR TITLE
threads.py: Add `--csv` option for CSV summary

### DIFF
--- a/tools/threads.py
+++ b/tools/threads.py
@@ -20,10 +20,26 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from dataclasses import dataclass
+from itertools import product
 import statistics
 import subprocess
 from utils.runner import *
 from utils.perfapp import *
+
+@dataclass
+class ThreadTestRun:
+    decoder: str
+    sequence: str
+    threads: int
+    asm: bool
+    fps: float
+
+    def readable(self):
+        return f"{self.sequence}, {self.decoder} {'asm' if self.asm else 'no asm'} {self.threads} threads: {self.fps} fps"
+
+    def csv(self):
+        return f"{self.decoder},{self.sequence},{self.threads},{self.asm},{self.fps}"
 
 class ThreadRunner(TestRunner):
     __summary = {}
@@ -35,10 +51,12 @@ class ThreadRunner(TestRunner):
         for f in files:
             self.__test(f)
 
+        print()
         self.__print_summary()
 
     def add_args(self, parser):
         parser.add_argument("--vvdec-path", type=str)
+        parser.add_argument("--csv", action="store_true")
 
     def __get_app(self):
         if self.args.vvdec_path:
@@ -47,37 +65,35 @@ class ThreadRunner(TestRunner):
 
     def __test(self, input):
         fn = os.path.basename(input)
-        self.__summary[fn] = [[], []]
-        for i in [1, 0]:
-            fps = self.__summary[fn][i]
-            for j in [16, 8, 4, 2, 1]:
-                self.__app.set_asm(i)
-                self.__app.set_threads(j)
-                cmd = self.__app.get_cmd(input)
-                print(cmd)
-                try:
-                    o = subprocess.run(cmd.split(), capture_output=True, timeout=5 * 60)
-                    if o.returncode:
-                        raise Exception(o.stderr)
-                    o = self.__app.get_fps(o)
-                    print("fps = ", o)
-                    fps.append(o)
-                except Exception as e:
-                    print(e)
-                    raise
+        self.runs = []
+
+        for asm, threads in product([True, False], [1, 2, 4, 8, 16]):
+            self.__app.set_asm(asm)
+            self.__app.set_threads(threads)
+            cmd = self.__app.get_cmd(input)
+            print(cmd)
+            try:
+                o = subprocess.run(cmd.split(), capture_output=True, timeout=5 * 60)
+                if o.returncode:
+                    raise Exception(o.stderr)
+                o = self.__app.get_fps(o)
+                print("fps = ", o)
+            except Exception as e:
+                print(e)
+                raise
+
+            run = ThreadTestRun("vvdec" if self.args.vvdec_path else "ffvvc", fn, threads, asm, o)
+            self.runs.append(run)
 
     def __print_summary(self):
-        for k,v in self.__summary.items():
-            print_summary(k, "no asm", v[0])
-            print_summary(k, "with asm", v[1])
-        pass
+        if self.args.csv:
+            print("Decoder,Sequence,Threads,SIMD,FPS")
 
-def print_summary(fn, msg, a):
-    s = fn + ", " + msg + " fps : {"
-    for fps in a:
-        s += " " + str(fps) + ","
-    s += " }"
-    print(s)
+        for run in self.runs:
+            if not self.args.csv:
+                print(run.readable())
+            else:
+                print(run.csv())
 
 if __name__ == "__main__":
     t = ThreadRunner()


### PR DESCRIPTION
Add a `--csv` flag to threads.py which outputs the summary in a CSV format.  I also refactored the app to make this easy, so the non-CSV summary is in a slightly different format: @nuomi2021 I wasn't sure if you were reading the old summary format programatically?  If so I can make a commit to make this PR backwards-compatible.