### PR TITLE
Tools: Allow passing multiple tests

### DIFF
--- a/tools/perf.py
+++ b/tools/perf.py
@@ -31,8 +31,7 @@ class PerformanceRunner(TestRunner):
     def run(self):
         self.__app = self.__get_app()
 
-        files = self.list_files(self.args.test_path)
-        for f in files:
+        for f in self.files:
             self.__test(f)
 
         self.__print_summary()

--- a/tools/threads.py
+++ b/tools/threads.py
@@ -31,8 +31,7 @@ class ThreadRunner(TestRunner):
     def run(self):
         self.__app = self.__get_app()
 
-        files = self.list_files(self.args.test_path)
-        for f in files:
+        for f in self.files:
             self.__test(f)
 
         self.__print_summary()

--- a/tools/utils/runner.py
+++ b/tools/utils/runner.py
@@ -27,7 +27,7 @@ class TestRunner:
     def check_input(self):
         parser = argparse.ArgumentParser(description="FFVVC test runner")
 
-        parser.add_argument("test_path", type=str)
+        parser.add_argument("test_path", type=str, nargs="+")
         parser.add_argument(
             "-f",
             "--ffmpeg-path",
@@ -67,4 +67,11 @@ class TestRunner:
                 fn = os.path.join(root, f)
                 if TestRunner.is_candidiate(fn):
                     l.append(fn)
+        return l
+
+    @property
+    def files(self):
+        l = []
+        for path in self.args.test_path:
+            l += TestRunner.list_files(path)
         return l


### PR DESCRIPTION
Allows passing multiple tests like:
```
python3 tools/ffmpeg.py --ffmpeg-path=./ffmpeg conformance/passed/v1/CCAALF_A_Sharp_3.bit conformance/passed/v2/10b444P12_A_Sony_2.bit
```
```
python3 tools/ffmpeg.py --ffmpeg-path=../ffmpeg conformance/passed/v1/{LMCS_A_Dolby_3.bit, SPS_A_Bytedance_1.bit}
```
```
python3 tools/ffmpeg.py --ffmpeg-path=../ffmpeg conformance/passed/v1/MTS*
```