### PR TITLE
Allow passing single `.yaml` files to test runner

### DIFF
--- a/tools/utils/runner.py
+++ b/tools/utils/runner.py
@@ -80,7 +80,11 @@ class TestRunner:
     @staticmethod
     def child_files(path):
         if os.path.isfile(path):
-            return [path]
+            filename, ext = os.path.splitext(path)
+            if ext == ".yaml":
+                return [filename + ext for ext in [".bin", ".bit", ".vvc", ".266"] if os.path.isfile(filename + ext)]
+            else:
+                return [path]
         else:
             return [os.path.join(dirpath, filename)
                     for dirpath, _, filenames in os.walk(path)


### PR DESCRIPTION
Improve the behaviour of 2558cd4cf47b95d72704f7101e7bdb72d4250730.  Allows passing single `.yaml` configuration files to the CLI, whereas before it could only take `.yaml` files as input if they fell under a directory.