### PR TITLE
Return error from ffmpeg.py for any failure type

### DIFF
--- a/tools/ffmpeg.py
+++ b/tools/ffmpeg.py
@@ -117,7 +117,10 @@ class ConformanceRunner(TestRunner):
                     summary[s].append(f)
 
         print_summary(summary, count)
-        sys.exit(count[TestResult.MISMATCH])
+        sys.exit(sum(count[status]
+            for status in count.keys()
+            if status not in [TestResult.PASSED, TestResult.SKIPPED]
+        ))
 
     def add_args(self, parser):
         parser.add_argument("-t", "--threads", type=int, default=16)


### PR DESCRIPTION
Before, ffmpeg.py would only return an error code, hence fail CI, if there was a mismatch, and not some other sort of error (timeout, segfault, etc.).  Correct this by failing if any sort of error occurs.