### PR TITLE
Add `-f vvc` to ffmpeg CLI arguments in ffmpeg.py

### DIFF
--- a/tools/ffmpeg.py
+++ b/tools/ffmpeg.py
@@ -131,7 +131,7 @@ class ConformanceRunner(TestRunner):
     def __ffmpeg_cmd(self, input_stream):
         return (
             self.args.ffmpeg_path
-            + " -strict -2 -i "
+            + " -strict -2 -f vvc -i "
             + input_stream
             + " -vsync 0 -noautoscale -an -map 0:v:0 -f md5 -"
         )


### PR DESCRIPTION
Sometimes fuzz files are not recognised as VVC bitstreams and so the test runner doesn't actually run the decoder on them, therefore we report no issue where the fuzzer actually found one.  By adding `-f vvc` we force the bitstream to actually be fed into the decoder.